### PR TITLE
Make insights logo responsive to mobile width

### DIFF
--- a/assets/components/announcement.scss
+++ b/assets/components/announcement.scss
@@ -6,7 +6,7 @@
             position: relative;
             width: 100%;
             margin: 0 auto;
-            padding: 15px 0;
+            padding: 15px 10px;
             p {
                 font-family: "open-sans-regular", arial, sans-serif;
                 font-style: normal;

--- a/assets/pages/page-blog.scss
+++ b/assets/pages/page-blog.scss
@@ -153,7 +153,6 @@ img[src$="cloudformation-launch-stack.png"] {
 .blog-headline-container::after {
   content: '.';
   background-image: url(/img/expert-insights-logo-tagline.svg);
-  width: 332px;
   height: 133px;
   background-repeat: no-repeat;
   display: block;

--- a/assets/pages/page-blog.scss
+++ b/assets/pages/page-blog.scss
@@ -120,7 +120,8 @@ img[src$="cloudformation-launch-stack.png"] {
   z-index: 1;
   padding: 120px 10.7% 120px 10.7%;
   @media screen and (max-width: 499px) {
-    padding: 40px 100px;
+    padding-top: 40px;
+    padding-bottom: 40px;
   }
   @media (min-width: 500px) and (max-width: 800px) {
     padding: 100px 100px;


### PR DESCRIPTION
The insights logo is going off the edge on mobile. This PR is to remove the width of the new insights logo so it can shrink on mobile and fit on mobile devices.