### PR TITLE
PLATEXP-5231: Rollback June 8 text and banners

### DIFF
--- a/assets/components/announcement.scss
+++ b/assets/components/announcement.scss
@@ -3,7 +3,6 @@
         background: #64005A;
         /*
         .banner::after {
-                /* This ::after is temporary for June 8, 2023 maintenance banner */
                 content: "NON-SERVICE DISRUPTING MAINTENANCE: On June 8, 2023, between 09:00 CDT and 12:00 CDT, docs.rackspace.com will be redirected to our new Website.";
                 display: block;
                 font-family: "open-sans-regular", arial, sans-serif;

--- a/assets/components/announcement.scss
+++ b/assets/components/announcement.scss
@@ -1,6 +1,7 @@
 .announcement {
     .header-announcement {
         background: #64005A;
+        /*
         .banner::after {
                 /* This ::after is temporary for June 8, 2023 maintenance banner */
                 content: "NON-SERVICE DISRUPTING MAINTENANCE: On June 8, 2023, between 09:00 CDT and 12:00 CDT, docs.rackspace.com will be redirected to our new Website.";
@@ -12,14 +13,14 @@
                 font-weight: 500;
                 line-height: 17px;
                 color: #FFF;    
-         }
+         }*/
         .banner {
             position: relative;
             width: 100%;
             margin: 0 auto;
             padding: 15px 10px;
             p {
-                display: none; /* using this to hide branding text across all websites and replace with warning in banner::after above */
+                /* display: none;  will use this to hide branding text across all websites when we un-comment banner::after above */
                 font-family: "open-sans-regular", arial, sans-serif;
                 font-style: normal;
                 text-align: center;

--- a/layouts/partials/components/announcement.html
+++ b/layouts/partials/components/announcement.html
@@ -1,8 +1,7 @@
 <section class="announcement">
     <div class="header-announcement">
         <div class="banner">
-          <p><strong>Non-Service Disrupting Maintenance:</strong> On June 8, 2023, Between 09:00 CDT and 12:00 CDT docs.rackspace.com will be redirected to our new Website.
-          </p>
+          <p>End-to-End Multicloud Solutions.&nbsp;&nbsp;&nbsp;<strong>Solving Together.™</strong>&nbsp;&nbsp;&nbsp;Learn more at <a href="https://www.rackspace.com/">Rackspace.com</a></p>
         </div>
       </div>
 </section>


### PR DESCRIPTION
JIRA: https://rackspace.atlassian.net/browse/PLATEXP-5231
Rolls back the June 8 announcement text
and CSS for all other sites from https://github.com/rackerlabs/docs-landing-page/pull/371
